### PR TITLE
send -1 distance in case of tf errors, null checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,23 +14,19 @@ find_package(ament_cmake REQUIRED)
 
 # --- Dependencies List ---
 set(DEPENDENCIES
-    Eigen3
     hector_worldmodel_msgs
     message_filters
     moveit_core
-    moveit_msgs
     moveit_ros_occupancy_map_monitor
-    OpenMP
+    octomap
+    octomap_msgs
     pluginlib
     rclcpp
     sensor_msgs
-    std_msgs
     std_srvs
     tf2
-    tf2_eigen
     tf2_geometry_msgs
     tf2_ros
-    urdf
     visualization_msgs)
 
 foreach(dep ${DEPENDENCIES})
@@ -40,8 +36,6 @@ endforeach()
 # --- Core Library ---
 add_library(${PROJECT_NAME}_core SHARED
             src/simple_pointcloud_octomap_updater.cpp)
-
-target_link_libraries(${PROJECT_NAME}_core OpenMP::OpenMP_CXX)
 
 target_include_directories(
   ${PROJECT_NAME}_core

--- a/include/simple_pointcloud_octomap_updater/simple_pointcloud_octomap_updater.hpp
+++ b/include/simple_pointcloud_octomap_updater/simple_pointcloud_octomap_updater.hpp
@@ -107,6 +107,11 @@ private:
   void publishOctomap();      // Lazy publisher callback (full map)
   void publishLocalOctomap(); // Lazy publisher callback (cropped/coarsened local map)
 
+  /** True once setMonitor() has wired up the shared octree and monitor. Any callback that
+   *  touches tree_/monitor_ must bail out (throttled warning) until this holds, because the
+   *  services are advertised in initialize() and can fire before the monitor is attached. */
+  bool treeReady() const;
+
   rclcpp::Node::SharedPtr node_;
 
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;

--- a/package.xml
+++ b/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>simple_pointcloud_octomap_updater</name>
   <version>2.13.0</version>
-  <description>Lightweight MoveIt occupancy map updater plugin that integrates pre-filtered point clouds into an octomap, exposes a distance-to-obstacle raycast service, and can publish a low-bandwidth local octomap for operator visualization.</description>
+  <description>Lightweight MoveIt occupancy map updater plugin that integrates pre-self-filtered point clouds into an octomap, exposes a distance-to-obstacle raycast service, and can publish a low-bandwidth local octomap for operator visualization.</description>
   <maintainer email="aljoscha.schmidt@tu-darmstadt.de">Aljoscha Schmidt</maintainer>
   <license>BSD-3-Clause</license>
 

--- a/package.xml
+++ b/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>simple_pointcloud_octomap_updater</name>
   <version>2.13.0</version>
-  <description>TODO</description>
+  <description>Lightweight MoveIt occupancy map updater plugin that integrates pre-filtered point clouds into an octomap, exposes a distance-to-obstacle raycast service, and can publish a low-bandwidth local octomap for operator visualization.</description>
   <maintainer email="aljoscha.schmidt@tu-darmstadt.de">Aljoscha Schmidt</maintainer>
   <license>BSD-3-Clause</license>
 
@@ -13,29 +13,19 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>eigen</build_depend>
-
-  <depend>glut</depend>
   <depend>hector_worldmodel_msgs</depend>
-  <depend>libglew-dev</depend>
-  <depend>libomp-dev</depend>
   <depend>message_filters</depend>
-  <depend>moveit_common</depend>
   <depend>moveit_core</depend>
-  <depend>moveit_msgs</depend>
   <depend>moveit_ros_occupancy_map_monitor</depend>
-  <depend>moveit_ros_planning</depend>
-  <depend>opengl</depend>
+  <depend>octomap</depend>
+  <depend>octomap_msgs</depend>
   <depend version_gte="1.11.2">pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
-  <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <depend>tf2</depend>
-  <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>urdf</depend>
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/src/simple_pointcloud_octomap_updater.cpp
+++ b/src/simple_pointcloud_octomap_updater.cpp
@@ -260,6 +260,11 @@ bool SimplePointCloudOctomapUpdater::initialize( const rclcpp::Node::SharedPtr &
   enable_octomap_service_ = node_->create_service<std_srvs::srv::SetBool>(
       "enable_octomap", [this]( const std_srvs::srv::SetBool::Request::SharedPtr req,
                                 const std_srvs::srv::SetBool::Response::SharedPtr res ) {
+        if ( !treeReady() ) {
+          res->success = false;
+          res->message = "Octomap not ready yet (monitor not attached)";
+          return;
+        }
         enabled_ = req->data;
         if ( !req->data ) {
           tree_->lockWrite();
@@ -278,8 +283,21 @@ bool SimplePointCloudOctomapUpdater::initialize( const rclcpp::Node::SharedPtr &
   return true;
 }
 
+bool SimplePointCloudOctomapUpdater::treeReady() const
+{
+  if ( tree_ && monitor_ ) {
+    return true;
+  }
+  RCLCPP_WARN_THROTTLE( logger_, *node_->get_clock(), 5000,
+                        "Octomap not ready yet (monitor not attached), ignoring request" );
+  return false;
+}
+
 void SimplePointCloudOctomapUpdater::publishOctomap()
 {
+  if ( !treeReady() ) {
+    return;
+  }
   // Lazy check: Only serialize and publish if there is at least one subscriber
   if ( global_viz_pub_->get_subscription_count() == 0 ) {
     return;
@@ -345,6 +363,9 @@ std::unique_ptr<octomap::OcTree> buildOccupiedTree( const std::vector<OccupiedBo
 
 void SimplePointCloudOctomapUpdater::publishLocalOctomap()
 {
+  if ( !treeReady() ) {
+    return;
+  }
   // Lazy check: Only extract and publish if there is at least one subscriber
   if ( local_viz_pub_->get_subscription_count() == 0 ) {
     return;
@@ -448,6 +469,9 @@ void SimplePointCloudOctomapUpdater::cloudMsgCallback(
   if ( !enabled_ )
     return;
 
+  if ( !treeReady() )
+    return;
+
   rclcpp::Time start = rclcpp::Clock( RCL_ROS_TIME ).now();
 
   if ( max_update_rate_ > 0 ) {
@@ -506,16 +530,12 @@ void SimplePointCloudOctomapUpdater::cloudMsgCallback(
     /* do ray tracing to find which cells this point cloud indicates should be free, and which it
      * indicates should be occupied */
     for ( unsigned int row = 0; row < cloud_msg->height; row += point_subsample_ ) {
-      unsigned int row_c = row * cloud_msg->width;
+      // Re-derive the iterator from the row start so that a width that is not a multiple of
+      // point_subsample_ does not carry an offset over into the next row.
       sensor_msgs::PointCloud2ConstIterator<float> pt_iter( *cloud_msg, "x" );
-      // set iterator to point at start of the current row
-      pt_iter += row_c;
-
+      pt_iter += static_cast<int>( row * cloud_msg->width );
       for ( unsigned int col = 0; col < cloud_msg->width;
             col += point_subsample_, pt_iter += point_subsample_ ) {
-        // if (mask_[row_c + col] == point_containment_filter::ShapeMask::CLIP)
-        //  continue;
-
         /* check for NaN */
         if ( !std::isnan( pt_iter[0] ) && !std::isnan( pt_iter[1] ) && !std::isnan( pt_iter[2] ) ) {
 
@@ -585,6 +605,15 @@ void SimplePointCloudOctomapUpdater::handleGetDistance(
     const hector_worldmodel_msgs::srv::GetDistanceToObstacle::Request::SharedPtr req,
     const hector_worldmodel_msgs::srv::GetDistanceToObstacle::Response::SharedPtr res )
 {
+  // Default response: no obstacle found
+  res->distance = -1.0;
+  res->end_point.header.stamp = node_->now();
+
+  if ( !treeReady() ) {
+    return;
+  }
+  res->end_point.header.frame_id = monitor_->getMapFrame();
+
   // get position of point stamped header frame in map frame
   tf2::Stamped<tf2::Transform> map_h_sensor;
   if ( monitor_->getMapFrame() == req->point.header.frame_id ) {
@@ -592,8 +621,9 @@ void SimplePointCloudOctomapUpdater::handleGetDistance(
   } else {
     if ( tf_buffer_ ) {
       try {
-        tf2::fromMsg( tf_buffer_->lookupTransform( monitor_->getMapFrame(), req->point.header.frame_id,
-                                                   req->point.header.stamp, rclcpp::Duration::from_seconds( tf_timeout_ ) ),
+        tf2::fromMsg( tf_buffer_->lookupTransform(
+                          monitor_->getMapFrame(), req->point.header.frame_id,
+                          req->point.header.stamp, rclcpp::Duration::from_seconds( tf_timeout_ ) ),
                       map_h_sensor );
       } catch ( tf2::TransformException &ex ) {
         RCLCPP_ERROR_STREAM( logger_, "Transform error of sensor data: " << ex.what()

--- a/src/simple_pointcloud_octomap_updater.cpp
+++ b/src/simple_pointcloud_octomap_updater.cpp
@@ -466,11 +466,9 @@ void SimplePointCloudOctomapUpdater::cloudMsgCallback(
 {
   RCLCPP_DEBUG( logger_, "Received a new point cloud message" );
 
-  if ( !enabled_ )
+  if ( !enabled_ || !treeReady() ) {
     return;
-
-  if ( !treeReady() )
-    return;
+  }
 
   rclcpp::Time start = rclcpp::Clock( RCL_ROS_TIME ).now();
 
@@ -608,6 +606,9 @@ void SimplePointCloudOctomapUpdater::handleGetDistance(
   // Default response: no obstacle found
   res->distance = -1.0;
   res->end_point.header.stamp = node_->now();
+  res->end_point.point.x = std::numeric_limits<double>::quiet_NaN();
+  res->end_point.point.y = std::numeric_limits<double>::quiet_NaN();
+  res->end_point.point.z = std::numeric_limits<double>::quiet_NaN();
 
   if ( !treeReady() ) {
     return;
@@ -644,13 +645,16 @@ void SimplePointCloudOctomapUpdater::handleGetDistance(
   octomap::point3d end_ray;
   bool hit = tree_->castRay( sensor_origin, direction, end_ray );
 
-  // compute distance to end ray and fill response
-  res->distance = hit ? ( sensor_origin - end_ray ).norm() : -1.0;
+  // compute distance to end ray and fill response - if no hit, distance is infinity
+  res->distance = hit ? ( sensor_origin - end_ray ).norm() : std::numeric_limits<double>::infinity();
   res->end_point.header.frame_id = monitor_->getMapFrame();
   res->end_point.header.stamp = node_->now();
-  res->end_point.point.x = end_ray.x();
-  res->end_point.point.y = end_ray.y();
-  res->end_point.point.z = end_ray.z();
+  // if not hit, end point is NaN (already set above)
+  if ( hit ) {
+    res->end_point.point.x = end_ray.x();
+    res->end_point.point.y = end_ray.y();
+    res->end_point.point.z = end_ray.z();
+  }
 
   // Publish marker
   geometry_msgs::msg::Point start_point;


### PR DESCRIPTION
## Summary
- **Distance service:** return `distance = -1.0` on TF failure instead of a
  default-constructed response (`0.0`), which read as "obstacle at zero distance."
- **Null-safety:** guard every `tree_`/`monitor_` access with a `treeReady()` check
- **Dependencies:** drop unused deps (eigen, OpenMP, urdf, moveit_msgs, glut/opengl,
  etc.) and add the directly-used `octomap`/`octomap_msgs`
